### PR TITLE
multicluster metrics

### DIFF
--- a/frontend/src/plugin-extensions/extensions/KubevirtContext.ts
+++ b/frontend/src/plugin-extensions/extensions/KubevirtContext.ts
@@ -10,6 +10,10 @@ type MulticlusterResource<T> = { cluster?: string } & T
 export type SearchResult<R extends K8sResourceCommon | K8sResourceCommon[]> = R extends (infer T)[]
   ? MulticlusterResource<T>[]
   : MulticlusterResource<R>
+export type UseUtilizationQueries = (
+  prometheusQueries: Record<string, string>,
+  duration: string
+) => Record<string, string>
 
 /** Properties type */
 export type KubevirtPluginData = {
@@ -24,6 +28,7 @@ export type KubevirtPluginData = {
   useMulticlusterSearchWatch: <T extends K8sResourceCommon | K8sResourceCommon[]>(
     watchOptions: WatchK8sResource
   ) => [SearchResult<T> | undefined, boolean, Error | undefined]
+  useUtilizationQueries: UseUtilizationQueries
 }
 
 export type KubevirtPluginDataProps = {

--- a/frontend/src/routes/Search/Details/useUtilizationQueries.ts
+++ b/frontend/src/routes/Search/Details/useUtilizationQueries.ts
@@ -1,0 +1,61 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { UseUtilizationQueries } from '../../../plugin-extensions/extensions/KubevirtContext'
+
+enum VMQueries {
+  CPU_REQUESTED = 'CPU_REQUESTED',
+  CPU_USAGE = 'CPU_USAGE',
+  FILESYSTEM_READ_USAGE = 'FILESYSTEM_READ_USAGE',
+  FILESYSTEM_USAGE_TOTAL = 'FILESYSTEM_TOTAL_USAGE',
+  FILESYSTEM_WRITE_USAGE = 'FILESYSTEM_WRITE_USAGE',
+  INSTANT_MIGRATION_DATA_PROCESSED = 'INSTANT_MIGRATION_DATA_PROCESSED',
+  INSTANT_MIGRATION_DATA_REMAINING = 'INSTANT_MIGRATION_DATA_REMAINING',
+  MEMORY_USAGE = 'MEMORY_USAGE',
+  MIGRATION_DATA_PROCESSED = 'MIGRATION_DATA_PROCESSED',
+  MIGRATION_DATA_REMAINING = 'MIGRATION_DATA_REMAINING',
+  MIGRATION_DISK_TRANSFER_RATE = 'MIGRATION_DISK_TRANSFER_RATE',
+  MIGRATION_MEMORY_DIRTY_RATE = 'MIGRATION_MEMORY_DIRTY_RATE',
+  NETWORK_IN_BY_INTERFACE_USAGE = 'NETWORK_IN_BY_INTERFACE_USAGE',
+  NETWORK_IN_USAGE = 'NETWORK_IN_USAGE',
+  NETWORK_OUT_BY_INTERFACE_USAGE = 'NETWORK_OUT_BY_INTERFACE_USAGE',
+  NETWORK_OUT_USAGE = 'NETWORK_OUT_USAGE',
+  NETWORK_TOTAL_BY_INTERFACE_USAGE = 'NETWORK_TOTAL_BY_INTERFACE_USAGE',
+  NETWORK_TOTAL_USAGE = 'NETWORK_TOTAL_USAGE',
+  STORAGE_IOPS_TOTAL = 'STORAGE_IOPS_TOTAL',
+}
+
+export const useUtilizationQueries: UseUtilizationQueries = (prometheusQueries, duration) => {
+  let queries = prometheusQueries
+  const searchParams = new URLSearchParams(decodeURIComponent(window.location.search))
+  const name = searchParams.get('name')
+  const namespace = searchParams.get('namespace')
+  const cluster = searchParams.get('cluster')
+  if (cluster) {
+    // convert prometheus query to thanos query
+    let query: string
+    queries = {}
+    const filter = `name='${name}',namespace='${namespace}',cluster='${cluster}'`
+    Object.keys(prometheusQueries).map((key) => {
+      switch (key) {
+        case VMQueries.CPU_USAGE:
+          query = `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{${filter}}[${duration}])) BY (cluster, name, namespace)`
+          break
+        case VMQueries.CPU_REQUESTED:
+          query = `sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="cores"}[${duration}])) *
+          sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="threads"}[${duration}])) *
+          sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="sockets"}[${duration}]))`
+          break
+        case VMQueries.FILESYSTEM_USAGE_TOTAL:
+          query = `sum by (name, namespace, cluster)(rate(kubevirt_vmi_storage_iops_read_total{${filter}}[${duration}])) + 
+            sum by (name, namespace, cluster)(rate(kubevirt_vmi_storage_iops_write_total{${filter}}[${duration}]))`
+          break
+        default:
+          query = prometheusQueries[key]?.replace(/\{([^}]+)\}/g, (_, key) => {
+            return `{${key},cluster='${cluster}'}`
+          })
+      }
+      queries[key] = query
+    })
+  }
+  return queries
+}

--- a/frontend/src/routes/Search/Details/useUtilizationQueries.ts
+++ b/frontend/src/routes/Search/Details/useUtilizationQueries.ts
@@ -41,17 +41,29 @@ export const useUtilizationQueries: UseUtilizationQueries = (prometheusQueries, 
           query = `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{${filter}}[${duration}])) BY (cluster, name, namespace)`
           break
         case VMQueries.CPU_REQUESTED:
-          query = `sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="cores"}[${duration}])) *
-          sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="threads"}[${duration}])) *
-          sum by (cluster, namespace, name, node)(last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="sockets"}[${duration}]))`
+          query = `sum by (cluster, namespace, name) ((last_over_time(kubevirt_vm_resource_requests{${filter},resource="cpu", unit="cores"}[${duration}])) 
+          * ignoring(unit) (last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="sockets"}[${duration}])) 
+          * ignoring(unit) (last_over_time(kubevirt_vm_resource_requests{${filter}, resource="cpu", unit="threads"}[${duration}])))`
           break
         case VMQueries.FILESYSTEM_USAGE_TOTAL:
           query = `sum by (name, namespace, cluster)(rate(kubevirt_vmi_storage_iops_read_total{${filter}}[${duration}])) + 
             sum by (name, namespace, cluster)(rate(kubevirt_vmi_storage_iops_write_total{${filter}}[${duration}]))`
           break
+        case VMQueries.NETWORK_OUT_USAGE:
+          query = `sum by (cluster, namespace, name, node)(kubevirt_vmi_network_receive_bytes_total{${filter}})`
+          break
+        case VMQueries.NETWORK_IN_USAGE:
+          query = `sum by (cluster, namespace, name, node)(kubevirt_vmi_network_transmit_bytes_total{${filter}})`
+          break
         default:
+          // for Prometheus queries, try just adding cluster label
+          // add cluster label to filter ex: metric_name{.., cluster='myCluster'}
           query = prometheusQueries[key]?.replace(/\{([^}]+)\}/g, (_, key) => {
             return `{${key},cluster='${cluster}'}`
+          })
+          // add cluster to Aggregation operators that use "by (label list)"
+          query = query.replace(/\(([^}]+)\)/g, (_, key) => {
+            return `{${key}, cluster}`
           })
       }
       queries[key] = query


### PR DESCRIPTION
introduces to context
**useUtilizationQueries** -- converts prometheus queries to observability
like this:

  const { useUtilizationQueries } = useContext(KubevirtPluginContext);
  const queries = useUtilizationQueries(getUtilizationQueries({ duration, obj: vmi }), duration);

where **getUtilizationQueries({ duration, obj: vmi })** is their query factory

**usePrometheusPoll** -- similar to useK8sWatchResource, kubevirt-plugin uses our usePrometheusPoll instead of ocp